### PR TITLE
Add Loan Eligibility Predictor project

### DIFF
--- a/loan-eligibility-predictor/.gitignore
+++ b/loan-eligibility-predictor/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+model/loan_model_v1.h5
+.env

--- a/loan-eligibility-predictor/README.md
+++ b/loan-eligibility-predictor/README.md
@@ -1,0 +1,13 @@
+# Loan Eligibility Predictor – ML Inference Monitoring App
+
+This app provides an API for predicting loan approval using a TensorFlow model. It logs predictions to MySQL and exposes Prometheus metrics for visualization in Grafana.
+
+## Usage
+
+Build and run all services:
+
+```bash
+docker-compose -f docker/docker-compose.yml up --build
+```
+
+The API will be available at `http://localhost:5000/predict`.

--- a/loan-eligibility-predictor/database/init.sql
+++ b/loan-eligibility-predictor/database/init.sql
@@ -1,0 +1,17 @@
+CREATE DATABASE IF NOT EXISTS loans;
+USE loans;
+
+CREATE TABLE IF NOT EXISTS loan_predictions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    age INT,
+    income FLOAT,
+    credit_score FLOAT,
+    loan_amount FLOAT,
+    loan_term INT,
+    employment_years FLOAT,
+    existing_debt FLOAT,
+    loan_approved BOOLEAN,
+    confidence_score FLOAT,
+    inference_time_ms FLOAT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/loan-eligibility-predictor/docker/Dockerfile
+++ b/loan-eligibility-predictor/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "flask_app.app"]

--- a/loan-eligibility-predictor/docker/docker-compose.yml
+++ b/loan-eligibility-predictor/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+services:
+  flask:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ..:/app
+    env_file:
+      - ../.env
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+      - ../database/init.sql:/docker-entrypoint-initdb.d/init.sql
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - flask
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ../grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - prometheus
+volumes:
+  db_data:
+  grafana_data:

--- a/loan-eligibility-predictor/flask_app/__init__.py
+++ b/loan-eligibility-predictor/flask_app/__init__.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/loan-eligibility-predictor/flask_app/app.py
+++ b/loan-eligibility-predictor/flask_app/app.py
@@ -1,0 +1,21 @@
+from flask import Flask
+from prometheus_flask_exporter import PrometheusMetrics
+
+from .routes import api_bp
+from .config import Config
+from .db import db
+
+metrics = PrometheusMetrics()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+    metrics.init_app(app)
+    app.register_blueprint(api_bp)
+    return app
+
+if __name__ == "__main__":
+    application = create_app()
+    application.run(host="0.0.0.0", port=5000)

--- a/loan-eligibility-predictor/flask_app/config.py
+++ b/loan-eligibility-predictor/flask_app/config.py
@@ -1,0 +1,7 @@
+import os
+
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URI', 'mysql+pymysql://user:password@db:3306/loans')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SECRET_KEY = os.getenv('SECRET_KEY', 'secret')

--- a/loan-eligibility-predictor/flask_app/db.py
+++ b/loan-eligibility-predictor/flask_app/db.py
@@ -1,0 +1,4 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()

--- a/loan-eligibility-predictor/flask_app/metrics.py
+++ b/loan-eligibility-predictor/flask_app/metrics.py
@@ -1,0 +1,3 @@
+from prometheus_client import Counter
+
+REQUEST_COUNT = Counter('predict_requests_total', 'Total predict requests')

--- a/loan-eligibility-predictor/flask_app/model.py
+++ b/loan-eligibility-predictor/flask_app/model.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+import numpy as np
+
+MODEL_PATH = 'model/loan_model_v1.h5'
+
+
+def load_model(path: str = MODEL_PATH):
+    return tf.keras.models.load_model(path)
+
+
+def predict(model, data: dict):
+    features = np.array([
+        [
+            data.get('age', 0),
+            data.get('income', 0.0),
+            data.get('credit_score', 0.0),
+            data.get('loan_amount', 0.0),
+            data.get('loan_term', 0),
+            data.get('employment_years', 0.0),
+            data.get('existing_debt', 0.0)
+        ]
+    ])
+    probs = model.predict(features, verbose=0)[0]
+    prediction = int(probs[0] > 0.5)
+    confidence = float(probs[0])
+    return prediction, confidence

--- a/loan-eligibility-predictor/flask_app/models.py
+++ b/loan-eligibility-predictor/flask_app/models.py
@@ -1,0 +1,16 @@
+from .db import db
+
+
+class LoanPrediction(db.Model):
+    __tablename__ = 'loan_predictions'
+    id = db.Column(db.Integer, primary_key=True)
+    age = db.Column(db.Integer)
+    income = db.Column(db.Float)
+    credit_score = db.Column(db.Float)
+    loan_amount = db.Column(db.Float)
+    loan_term = db.Column(db.Integer)
+    employment_years = db.Column(db.Float)
+    existing_debt = db.Column(db.Float)
+    loan_approved = db.Column(db.Boolean)
+    confidence_score = db.Column(db.Float)
+    inference_time_ms = db.Column(db.Float)

--- a/loan-eligibility-predictor/flask_app/routes.py
+++ b/loan-eligibility-predictor/flask_app/routes.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, request, jsonify
+from time import time
+
+from .model import load_model, predict
+from .db import db
+from .metrics import REQUEST_COUNT
+
+api_bp = Blueprint('api', __name__)
+model = load_model()
+
+
+@api_bp.route('/predict', methods=['POST'])
+def predict_route():
+    start_time = time()
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'Invalid input'}), 400
+
+    prediction, confidence = predict(model, data)
+
+    inference_time = (time() - start_time) * 1000
+    REQUEST_COUNT.inc()
+
+    # Log into DB
+    from .models import LoanPrediction
+    record = LoanPrediction(
+        age=data.get('age'),
+        income=data.get('income'),
+        credit_score=data.get('credit_score'),
+        loan_amount=data.get('loan_amount'),
+        loan_term=data.get('loan_term'),
+        employment_years=data.get('employment_years'),
+        existing_debt=data.get('existing_debt'),
+        loan_approved=bool(prediction),
+        confidence_score=float(confidence),
+        inference_time_ms=inference_time
+    )
+    db.session.add(record)
+    db.session.commit()
+
+    return jsonify({
+        'loan_approved': bool(prediction),
+        'confidence_score': float(confidence),
+        'model_version': 'v1.0',
+        'inference_time_ms': inference_time
+    })

--- a/loan-eligibility-predictor/grafana/dashboards/loan_dashboard.json
+++ b/loan-eligibility-predictor/grafana/dashboards/loan_dashboard.json
@@ -1,0 +1,18 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Loan Predictions",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "Prediction Requests",
+        "targets": [
+          {
+            "expr": "predict_requests_total",
+            "legendFormat": "requests"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/loan-eligibility-predictor/jenkins/Jenkinsfile
+++ b/loan-eligibility-predictor/jenkins/Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                sh 'docker-compose -f docker/docker-compose.yml build'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'echo "Running tests"'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh 'docker-compose -f docker/docker-compose.yml up -d'
+            }
+        }
+    }
+}

--- a/loan-eligibility-predictor/model/train_model.py
+++ b/loan-eligibility-predictor/model/train_model.py
@@ -1,0 +1,23 @@
+import numpy as np
+import tensorflow as tf
+
+
+def generate_data(samples=1000):
+    X = np.random.rand(samples, 7)
+    y = (X.sum(axis=1) > 3.5).astype(int)
+    return X, y
+
+
+def train():
+    X, y = generate_data()
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(16, activation='relu', input_shape=(7,)),
+        tf.keras.layers.Dense(1, activation='sigmoid')
+    ])
+    model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])
+    model.fit(X, y, epochs=5)
+    model.save('model/loan_model_v1.h5')
+
+
+if __name__ == '__main__':
+    train()

--- a/loan-eligibility-predictor/prometheus/prometheus.yml
+++ b/loan-eligibility-predictor/prometheus/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: 'flask'
+    static_configs:
+      - targets: ['flask:5000']

--- a/loan-eligibility-predictor/requirements.txt
+++ b/loan-eligibility-predictor/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-SQLAlchemy
+pymysql
+prometheus-flask-exporter
+tensorflow


### PR DESCRIPTION
## Summary
- create Flask API with prediction routes and model loading
- add SQLAlchemy models and Prometheus metrics
- include TensorFlow training script and database init SQL
- provide Docker, docker-compose, Prometheus, Grafana, Jenkins setup
- document usage in README

## Testing
- `python -m py_compile loan-eligibility-predictor/flask_app/*.py loan-eligibility-predictor/model/train_model.py`
- ❌ `docker-compose -f loan-eligibility-predictor/docker/docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686441623d8c833085f58eff69d637d8