### PR TITLE
Fix dummy model and add simple frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,11 @@ Build and run all services:
 docker-compose -f docker/docker-compose.yml up --build
 ```
 
-The API will be available at `http://localhost:5000/predict`.
+The API will be available at `http://localhost:5000/predict`. A simple HTML
+front‑end form is served at `http://localhost:5000/`.
+
+To generate a dummy model locally for testing you can run:
+
+```bash
+python model/generate_dummy_model.py
+```

--- a/flask_app/routes.py
+++ b/flask_app/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, render_template
 from time import time
 
 from .model import load_model, predict
@@ -10,6 +10,10 @@ api_bp = Blueprint('api', __name__)
 
 # Load ML model once at blueprint load time
 model = load_model()
+
+@api_bp.route('/')
+def index():
+    return render_template('index.html')
 
 @api_bp.route('/predict', methods=['POST'])
 def predict_route():

--- a/flask_app/static/style.css
+++ b/flask_app/static/style.css
@@ -1,0 +1,12 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+    background-color: #f5f5f5;
+}
+form label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+button {
+    margin-top: 1rem;
+}

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Loan Eligibility Predictor</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Loan Eligibility Predictor</h1>
+    <form id="predict-form">
+        <label>Age: <input type="number" name="age" required></label>
+        <label>Income: <input type="number" name="income" step="0.01" required></label>
+        <label>Credit Score: <input type="number" name="credit_score" step="0.01" required></label>
+        <label>Loan Amount: <input type="number" name="loan_amount" step="0.01" required></label>
+        <label>Loan Term: <input type="number" name="loan_term" required></label>
+        <label>Employment Years: <input type="number" name="employment_years" step="0.1" required></label>
+        <label>Existing Debt: <input type="number" name="existing_debt" step="0.01" required></label>
+        <button type="submit">Predict</button>
+    </form>
+    <pre id="result"></pre>
+    <script>
+        const form = document.getElementById('predict-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const data = Object.fromEntries(new FormData(form));
+            const response = await fetch('/predict', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            const result = await response.json();
+            document.getElementById('result').textContent = JSON.stringify(result, null, 2);
+        });
+    </script>
+</body>
+</html>

--- a/model/generate_dummy_model.py
+++ b/model/generate_dummy_model.py
@@ -5,14 +5,14 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense
 import numpy as np
 
-# Generate dummy input and output
-X = np.random.rand(100, 3)  # 3 features: age, income, credit score
+# Generate dummy input and output matching the API's 7 features
+X = np.random.rand(100, 7)
 y = np.random.randint(0, 2, size=(100, 1))  # Binary output: approved (1) or not (0)
 
-# Define a simple model
+# Define a simple model with the correct input shape
 model = Sequential([
-    Dense(8, activation='relu', input_shape=(3,)),
-    Dense(4, activation='relu'),
+    Dense(16, activation='relu', input_shape=(7,)),
+    Dense(8, activation='relu'),
     Dense(1, activation='sigmoid')
 ])
 


### PR DESCRIPTION
## Summary
- match dummy model input shape with API
- provide simple HTML/CSS frontend
- expose index route
- document how to generate dummy model

## Testing
- `python -m py_compile flask_app/routes.py model/generate_dummy_model.py`
- `python model/generate_dummy_model.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68691513e0c883309dc37896c0f24915