### PR TITLE
Fix prediction input handling and model generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,24 @@ docker-compose -f docker/docker-compose.yml up --build
 The API will be available at `http://localhost:5000/predict`. A simple HTML
 front‑end form is served at `http://localhost:5000/`.
 
-To generate a dummy model locally for testing you can run:
+To generate a dummy model with the required **seven** input features run:
 
 ```bash
 python model/generate_dummy_model.py
+```
+
+This will create `model/loan_model_v1.h5`. Ensure it exists before starting the API so the prediction endpoint can load it correctly.
+
+Example payload:
+
+```json
+{
+  "age": 30,
+  "income": 600000,
+  "credit_score": 750,
+  "loan_amount": 250000,
+  "loan_term": 10,
+  "employment_years": 4,
+  "existing_debt": 10000
+}
 ```

--- a/flask_app/model.py
+++ b/flask_app/model.py
@@ -9,17 +9,18 @@ def load_model(path: str = MODEL_PATH):
 
 
 def predict(model, data: dict):
+    """Convert incoming dictionary to a numeric numpy array for the model."""
     features = np.array([
         [
-            data.get('age', 0),
-            data.get('income', 0.0),
-            data.get('credit_score', 0.0),
-            data.get('loan_amount', 0.0),
-            data.get('loan_term', 0),
-            data.get('employment_years', 0.0),
-            data.get('existing_debt', 0.0)
+            float(data.get('age', 0)),
+            float(data.get('income', 0.0)),
+            float(data.get('credit_score', 0.0)),
+            float(data.get('loan_amount', 0.0)),
+            float(data.get('loan_term', 0)),
+            float(data.get('employment_years', 0.0)),
+            float(data.get('existing_debt', 0.0))
         ]
-    ])
+    ], dtype=np.float32)
     probs = model.predict(features, verbose=0)[0]
     prediction = int(probs[0] > 0.5)
     confidence = float(probs[0])

--- a/flask_app/routes.py
+++ b/flask_app/routes.py
@@ -24,7 +24,20 @@ def predict_route():
         return jsonify({'error': 'Invalid or missing JSON'}), 400
 
     try:
-        prediction, confidence = predict(model, data)
+        numeric_data = {
+            'age': float(data.get('age', 0)),
+            'income': float(data.get('income', 0.0)),
+            'credit_score': float(data.get('credit_score', 0.0)),
+            'loan_amount': float(data.get('loan_amount', 0.0)),
+            'loan_term': float(data.get('loan_term', 0)),
+            'employment_years': float(data.get('employment_years', 0.0)),
+            'existing_debt': float(data.get('existing_debt', 0.0))
+        }
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Invalid input data types'}), 400
+
+    try:
+        prediction, confidence = predict(model, numeric_data)
     except Exception as e:
         return jsonify({'error': f'Model prediction failed: {str(e)}'}), 500
 
@@ -34,13 +47,13 @@ def predict_route():
     try:
         from .models import LoanPrediction
         record = LoanPrediction(
-            age=data.get('age'),
-            income=data.get('income'),
-            credit_score=data.get('credit_score'),
-            loan_amount=data.get('loan_amount'),
-            loan_term=data.get('loan_term'),
-            employment_years=data.get('employment_years'),
-            existing_debt=data.get('existing_debt'),
+            age=int(numeric_data['age']),
+            income=numeric_data['income'],
+            credit_score=numeric_data['credit_score'],
+            loan_amount=numeric_data['loan_amount'],
+            loan_term=int(numeric_data['loan_term']),
+            employment_years=numeric_data['employment_years'],
+            existing_debt=numeric_data['existing_debt'],
             loan_approved=bool(prediction),
             confidence_score=float(confidence),
             inference_time_ms=inference_time

--- a/model/generate_dummy_model.py
+++ b/model/generate_dummy_model.py
@@ -1,17 +1,21 @@
 # model/generate_dummy_model.py
 
+import sys
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense
 import numpy as np
 
-# Generate dummy input and output matching the API's 7 features
-X = np.random.rand(100, 7)
+# Allow overriding the number of input features via CLI for flexibility.
+num_features = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+
+# Generate dummy input and output matching the API's expected features
+X = np.random.rand(100, num_features)
 y = np.random.randint(0, 2, size=(100, 1))  # Binary output: approved (1) or not (0)
 
 # Define a simple model with the correct input shape
 model = Sequential([
-    Dense(16, activation='relu', input_shape=(7,)),
+    Dense(16, activation='relu', input_shape=(num_features,)),
     Dense(8, activation='relu'),
     Dense(1, activation='sigmoid')
 ])


### PR DESCRIPTION
## Summary
- make `predict` convert incoming values to float arrays
- ensure `/predict` endpoint parses input numbers correctly before model call
- allow `generate_dummy_model.py` to accept feature count
- document model generation and sample JSON payload

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c1fd86b08833080ae19987b44605b