### PR TITLE
Fix dummy model feature count

### DIFF
--- a/model/generate_dummy_model.py
+++ b/model/generate_dummy_model.py
@@ -1,13 +1,14 @@
 # model/generate_dummy_model.py
 
-import sys
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense
 import numpy as np
 
-# Allow overriding the number of input features via CLI for flexibility.
-num_features = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+# The /predict API expects seven features.  Keep the model definition
+# consistent and do not rely on command line arguments for the feature
+# count so Docker builds behave predictably.
+num_features = 7
 
 # Generate dummy input and output matching the API's expected features
 X = np.random.rand(100, num_features)


### PR DESCRIPTION
## Summary
- use a fixed seven-feature input shape in `generate_dummy_model.py`

## Testing
- `python3 -m py_compile model/generate_dummy_model.py`
- `python3 model/generate_dummy_model.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `docker run --rm -v "$(pwd):/app" -w /app python:3.10 bash -c "pip install tensorflow && python model/generate_dummy_model.py"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec856f9cc83309f554105dd32d9c1