### PR TITLE
Add web-based prediction route with styled result

### DIFF
--- a/flask_app/routes.py
+++ b/flask_app/routes.py
@@ -69,3 +69,40 @@ def predict_route():
         'model_version': 'v1.0',
         'inference_time_ms': inference_time
     })
+
+
+@api_bp.route('/predict-ui', methods=['POST'])
+def predict_ui():
+    """Handle form submissions and display a friendly result page."""
+    start_time = time()
+
+    try:
+        features = [
+            float(request.form.get('age', 0)),
+            float(request.form.get('income', 0.0)),
+            float(request.form.get('credit_score', 0.0)),
+            float(request.form.get('loan_amount', 0.0)),
+            float(request.form.get('loan_term', 0)),
+            float(request.form.get('employment_years', 0.0)),
+            float(request.form.get('existing_debt', 0.0)),
+        ]
+    except (TypeError, ValueError):
+        return render_template(
+            'index.html',
+            result='Invalid input data',
+            result_class='danger'
+        )
+
+    # Run model prediction
+    prediction_probs = model.predict([features], verbose=0)[0][0]
+    eligible = prediction_probs >= 0.5
+
+    inference_time = (time() - start_time) * 1000
+
+    return render_template(
+        'index.html',
+        result='Loan Approved' if eligible else 'Loan Not Approved',
+        result_class='success' if eligible else 'danger',
+        confidence=float(prediction_probs),
+        inference_time=inference_time
+    )

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -5,11 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Loan Eligibility Predictor</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <style>
+      .success {
+        color: green;
+        font-weight: bold;
+        font-size: 18px;
+        margin-top: 15px;
+      }
+      .danger {
+        color: red;
+        font-weight: bold;
+        font-size: 18px;
+        margin-top: 15px;
+      }
+    </style>
 </head>
 <body>
     <div class="container">
         <h1>Loan Eligibility Predictor</h1>
-        <form id="predict-form" novalidate>
+        <form action="/predict-ui" method="POST" id="predict-form" novalidate>
             <label>Age
                 <input type="number" name="age" min="0" required>
             </label>
@@ -33,37 +47,9 @@
             </label>
             <button type="submit">Predict</button>
         </form>
-        <div id="result" class="hidden"></div>
+        {% if result %}
+          <div class="{{ result_class }}">{{ result }}</div>
+        {% endif %}
     </div>
-    <script>
-        const form = document.getElementById('predict-form');
-        const resultEl = document.getElementById('result');
-
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const data = Object.fromEntries(new FormData(form));
-
-            // Basic client-side validation
-            for (const value of Object.values(data)) {
-                if (value === '' || Number(value) < 0) {
-                    resultEl.textContent = 'Please fill out all fields with valid positive numbers.';
-                    resultEl.className = 'error';
-                    return;
-                }
-            }
-
-            const response = await fetch('/predict', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            });
-
-            const text = await response.text();
-            const approved = text.trim().toLowerCase() === 'true' || text.trim() === '1';
-
-            resultEl.textContent = approved ? 'Loan Approved' : 'Loan Not Approved';
-            resultEl.className = approved ? 'approved' : 'denied';
-        });
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/predict-ui` route for HTML form submissions
- style result feedback and update form action
- remove old JS-driven prediction logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873c44a464883308bc8efd8e9521a3f